### PR TITLE
fix for Possible precedence issue with control flow operator

### DIFF
--- a/lib/IPC/Semaphore/Concurrency.pm
+++ b/lib/IPC/Semaphore/Concurrency.pm
@@ -71,7 +71,7 @@ sub _touch {
 sub _ftok {
 	# Create an IPC key, returns result of ftok()
 	my $self = shift;
-	return ftok($self->{'_args'}->{'path'}, $self->{'_args'}->{'project'})
+	(return ftok($self->{'_args'}->{'path'}, $self->{'_args'}->{'project'}))
 		or carp "Can't create semaphore key: $!" and return undef;
 }
 


### PR DESCRIPTION
at lib/IPC/Semaphore/Concurrency.pm line 75.

```
$ perl -v

This is perl 5, version 28, subversion 1 (v5.28.1) built for x86_64-linux
```


